### PR TITLE
Category urls from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Or download and copy the `src` directory into `app/code/Elgentos/RegenerateCatal
 ```
 Usage:
  regenerate:product:url [-s|--store="..."] [pids1] ... [pidsN]
- regenerate:category:url [-s]--store="..."] [cids1] ... [cidsN]
- regenerate:category:path [-s]--store="..."] [cids1] ... [cidsN]
+ regenerate:category:url [-s]--store="..."] [-r]--root="..."] [cids1] ... [cidsN]
+ regenerate:category:path [-s]--store="..."] [-r]--root="..."] [cids1] ... [cidsN]
  regenerate:cms-page:url [-s]--store="..."] [pids1] ... [pidsN]
 
 Arguments:
@@ -32,6 +32,7 @@ Arguments:
 
 Options:
  --store (-s)          Use a specific store (store Id, store code or 'all')
+ --root (-r)           Regenerate for root category and its children, ignoring cids. 
  --help (-h)           Display this help message
 ```
 
@@ -45,6 +46,9 @@ php bin/magento regenerate:product:url -s1 1 2 3 4
 
 # Regenerate url for all CMS pages
 php bin/magento regenerate:cms-page:url -s all
+
+# Regenerate url for root category 4 and its children for store 1
+php bin/magento regenerate:category:url -s1 -r4
 ```
 
 ## FAQ

--- a/src/Console/Command/RegenerateCategoryPathCommand.php
+++ b/src/Console/Command/RegenerateCategoryPathCommand.php
@@ -15,6 +15,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\Framework\App\State;

--- a/src/Console/Command/RegenerateCategoryPathCommand.php
+++ b/src/Console/Command/RegenerateCategoryPathCommand.php
@@ -99,8 +99,7 @@ class RegenerateCategoryPathCommand extends AbstractRegenerateCommand
                     'like' => '1/' . $fromRootOnly . '/%',
                     '='    => '1/' . $fromRootOnly
                 ]);
-            }
-            else if (!empty($categoryIds)) {
+            } elseif (!empty($categoryIds)) {
                 $categories->addAttributeToFilter('entity_id', ['in' => $categoryIds]);
             }
 

--- a/src/Console/Command/RegenerateCategoryPathCommand.php
+++ b/src/Console/Command/RegenerateCategoryPathCommand.php
@@ -54,7 +54,7 @@ class RegenerateCategoryPathCommand extends AbstractRegenerateCommand
                 InputArgument::IS_ARRAY,
                 'Categories to regenerate'
             )->addOption(
-                'cfromrootid',
+                'root',
                 'r',
                 InputOption::VALUE_OPTIONAL,
                 'Regenerate for root category and its children only',
@@ -91,7 +91,7 @@ class RegenerateCategoryPathCommand extends AbstractRegenerateCommand
                 ->addAttributeToSelect(['name', 'url_path', 'url_key', 'path'])
                 ->addAttributeToFilter('level', ['gt' => 1]);
 
-            $fromRootOnly = intval($input->getOption('cfromrootid')) ?? 0;
+            $fromRootOnly = intval($input->getOption('root')) ?? 0;
             $categoryIds = $input->getArgument('cids');
             if ($fromRootOnly) {
                 //path LIKE '1/rootcategory/%' OR path = '1/rootcategory'

--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -60,7 +60,7 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
                 InputArgument::IS_ARRAY,
                 'Categories to regenerate'
             )->addOption(
-                'cfromrootid',
+                'root',
                 'r',
                 InputOption::VALUE_OPTIONAL,
                 'Regenerate for root category and its children only',
@@ -100,7 +100,7 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
                 ->addAttributeToSelect(['name', 'url_path', 'url_key', 'path'])
                 ->addAttributeToFilter('level', ['gt' => 1]);
 
-            $fromRootId = intval($input->getOption('cfromrootid')) ?? 0;
+            $fromRootId = intval($input->getOption('root')) ?? 0;
             $categoryIds = $input->getArgument('cids');
             if ($fromRootId) {
                 //path LIKE '1/rootcategory/%' OR path = '1/rootcategory'

--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -59,6 +59,12 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
                 'cids',
                 InputArgument::IS_ARRAY,
                 'Categories to regenerate'
+            )->addOption(
+                'cfromrootid',
+                'r',
+                InputOption::VALUE_OPTIONAL,
+                'Regenerate for root category and its children only',
+                false
             );
 
         parent::configure();
@@ -94,9 +100,16 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
                 ->addAttributeToSelect(['name', 'url_path', 'url_key'])
                 ->addAttributeToFilter('level', ['gt' => 1]);
 
+            $fromRootId = intval($input->getOption('cfromrootid')) ?? 0;
             $categoryIds = $input->getArgument('cids');
-
-            if (!empty($categoryIds)) {
+            if ($fromRootId) {
+                //path LIKE '1/rootcategory/%' OR path = '1/rootcategory'
+                $categories->addAttributeToFilter('path', [
+                    'like' => '1/' . $fromRootId . '/%',
+                    '='    => '1/' . $fromRootId
+                ]);
+            }
+            else if (!empty($categoryIds)) {
                 $categories->addAttributeToFilter('entity_id', ['in' => $categoryIds]);
             }
 

--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -97,7 +97,7 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
 
             $categories = $this->categoryCollectionFactory->create()
                 ->setStore($storeId)
-                ->addAttributeToSelect(['name', 'url_path', 'url_key'])
+                ->addAttributeToSelect(['name', 'url_path', 'url_key', 'path'])
                 ->addAttributeToFilter('level', ['gt' => 1]);
 
             $fromRootId = intval($input->getOption('cfromrootid')) ?? 0;

--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -15,6 +15,7 @@ use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;

--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -108,8 +108,7 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
                     'like' => '1/' . $fromRootId . '/%',
                     '='    => '1/' . $fromRootId
                 ]);
-            }
-            else if (!empty($categoryIds)) {
+            } elseif (!empty($categoryIds)) {
                 $categories->addAttributeToFilter('entity_id', ['in' => $categoryIds]);
             }
 


### PR DESCRIPTION
Closing https://github.com/elgentos/magento2-regenerate-catalog-urls/issues/42

We have multiple websites & stores and every website has its own category tree. So when regenerating the urls for a storeview we only want to regenerate them for the category tree that the store uses (to prevent clutter).

With this pull request we are able to do this. Please let me know if you have any comments.