### PR TITLE
Improved product URL error message to show which URLs were not unique

### DIFF
--- a/src/Service/RegenerateProductUrl.php
+++ b/src/Service/RegenerateProductUrl.php
@@ -137,7 +137,7 @@ class RegenerateProductUrl
             } catch (\Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException $e) {
                 $this->log(sprintf(
                     '<error>Couldn\'t insert duplicate URL rewrites for the following ' .
-                    'products on store ID %d:' . PHP_EOL . '%s</error>',
+                    'products on store ID %d (current batch failed):' . PHP_EOL . '%s</error>',
                     $store->getId(),
                     implode(PHP_EOL, array_map(function ($url) {
                         return sprintf(

--- a/src/Service/RegenerateProductUrl.php
+++ b/src/Service/RegenerateProductUrl.php
@@ -134,6 +134,19 @@ class RegenerateProductUrl
                 if (count($newUrls)) {
                     $regeneratedForStore += $this->replaceUrls($newUrls, true);
                 }
+            } catch (\Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException $e) {
+                $this->log(sprintf(
+                    '<error>Couldn\'t insert duplicate URL rewrites for the following ' .
+                    'products on store ID %d:' . PHP_EOL . '%s</error>',
+                    $store->getId(),
+                    implode(PHP_EOL, array_map(function ($url) {
+                        return sprintf(
+                            '- Product ID: %d, request path: %s',
+                            $url['entity_id'],
+                            $url['request_path']
+                        );
+                    }, $e->getUrls()))
+                ));
             } catch (Exception $e) {
                 $this->log(
                     sprintf(


### PR DESCRIPTION
If the exception is of type `\Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException`, we can actually get the list of URL rewrites that failed by calling its `getUrls` method.

I needed this for a project where I couldn't use the [baldwin module]([baldwin/magento2-module-url-data-integrity-checker](https://github.com/baldwin-agency/magento2-module-url-data-integrity-checker).) because it doesn't show URL clashes between 301/302 URLs, product URLs and category URLs (I believe that it can only show duplicate URLs of a single entity type).

To be honest, the next catch clause can probably be dropped entirely. (I don't mind the initial exception being caught/processed by Symfony command.)

Also, it needs to be clear that even one error will cause the entire batch of ~500 URLs to be rolled back and fail. Maybe I could add that to the error msg?