### PR TITLE
Proxy Emulation class in RegenerateProductUrl

### DIFF
--- a/src/Service/RegenerateProductUrl.php
+++ b/src/Service/RegenerateProductUrl.php
@@ -46,7 +46,7 @@ class RegenerateProductUrl
      */
     public function __construct(
         CollectionFactory $collectionFactory,
-        ProductUrlRewriteGenerator $urlRewriteGenerator,
+        ProductUrlRewriteGenerator\Proxy $urlRewriteGenerator,
         UrlPersistInterface $urlPersist,
         StoreManagerInterface $storeManager
     ) {


### PR DESCRIPTION
Introduced another proxy in a constructor to avoid database access through `bin/magento`

This class isn't directly used in the Command classes, but the waterfall of constructors that get called eventually end up with this class.

Together with #78, this should fully fix #76


Tested on Magento 2.4.6-p3 (with https://github.com/magento/magento2/pull/37424 as patch applied) and on the `2.4-develop` branch of `magento/magento2` github repo.