### PR TITLE
Fix: take 'cids' argument into account

### DIFF
--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -132,7 +132,8 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
                     'like' => '1/' . $fromRootId . '/%',
                     '='    => '1/' . $fromRootId
                 ]);
-            } elseif (!empty($categoryIds)) {
+            }
+            if (!empty($categoryIds)) {
                 $categories->addAttributeToFilter('entity_id', ['in' => $categoryIds]);
             }
 


### PR DESCRIPTION
The argument was always ignored, because the `$fromRootId` variable always contained a truthy value, after which the `elseif` was never reached.