### PR TITLE
Feature/create better error handling

### DIFF
--- a/src/Service/RegenerateProductUrl.php
+++ b/src/Service/RegenerateProductUrl.php
@@ -215,7 +215,17 @@ class RegenerateProductUrl
     private function replaceUrls(array &$urls, bool $last = false): int
     {
         $this->log(sprintf('replaceUrls%s batch: %d', $last ? ' last' : '', count($urls)));
-        $this->urlPersist->replace($urls);
+
+        foreach ($urls as $url) {
+            try {
+                $this->urlPersist->replace([$url]);
+            } catch (UrlAlreadyExistsException $e) {
+                $this->log(sprintf($e->getMessage(). ' Entity id: %d Request path: %s',
+                    $url->getEntityId(),
+                    $url->getRequestPath()
+                ));
+            }
+        }
         $count = count($urls);
         $urls  = [];
 


### PR DESCRIPTION
Move try catch to replaceUrls method.
Now the regeneration of product url's will no longer be interrupted when a duplicated URL has been detected.
The duplicated URL will be written to the console so the user can decide how to proceed.
Rewriting will continue for all other valid url's

Solving issue https://github.com/elgentos/magento2-regenerate-catalog-urls/issues/86