### PR TITLE
This id should be an integer instead of string since we do strict typ…

### DIFF
--- a/src/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/src/Console/Command/RegenerateCategoryUrlCommand.php
@@ -114,7 +114,7 @@ class RegenerateCategoryUrlCommand extends AbstractRegenerateCommand
         $rootIdOption = (int)$input->getOption('root') ?: false;
 
         foreach ($stores as $storeId) {
-            $currentRootId = $this->storeManager->getGroup(
+            $currentRootId = (int)$this->storeManager->getGroup(
                 $this->storeManager->getStore($storeId)->getStoreGroupId()
             )->getRootCategoryId();
             if ($rootIdOption !== false) {


### PR DESCRIPTION
…e checking against an integer on line 122

I ran into this problem after seeing this output:
```
$ bin/magento regenerate:category:url --root=132 --store=18
Skipping store 18 because its root category id 132, differs from the passed root category 132
Done regenerating. Regenerated 0 urls
```

It looks like this problem was introduced in #90, [on this line](https://github.com/elgentos/magento2-regenerate-catalog-urls/pull/90/files#diff-32880bc9a73eddc309cd809ad494c685980f0e64ed3fe48e9a402e4f704d5d9fL99) by accident by removing the `intval` call over there.

After this fix, the command runs correctly again:
```
$ bin/magento regenerate:category:url --root=132 --store=18
Processing store 18...
Regenerating urls for ...
...
```